### PR TITLE
Catch no synonyms error

### DIFF
--- a/cypress/fixtures/thesaurus-carrot.json
+++ b/cypress/fixtures/thesaurus-carrot.json
@@ -1,0 +1,22 @@
+[
+  "cargo",
+  "parrot",
+  "karroo",
+  "carrion",
+  "carry out",
+  "garrote",
+  "carried",
+  "parrots",
+  "charred",
+  "barrow",
+  "corrode",
+  "carbon",
+  "cared",
+  "carry",
+  "carry-cot",
+  "harrow",
+  "marrow",
+  "narrow",
+  "carrions",
+  "carry on"
+  ]

--- a/cypress/integration/Generator_spec.js
+++ b/cypress/integration/Generator_spec.js
@@ -13,4 +13,15 @@ describe('Generator', () => {
   it('should display a list of synonyms', () => {
     cy.get('.cy-synonym-radio-btn').should('be.visible')
   })
+
+  it('should display an error message if there are no synonyms', () => {
+    cy.intercept(
+      'https://www.dictionaryapi.com/api/v3/references/thesaurus/json/carrot?key=eea1834b-5c27-4dff-8bdf-54448122d3cc',
+      {fixture: 'thesaurus-carrot.json'}
+    )
+      .visit('http://localhost:3000/')
+      .get('.cy-input').type('carrot')
+      .get('.cy-button').click()
+      .get('.error-message-box').should('have.text', 'No synonyms found. Please try another keyword.')
+  })
 });

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -13,5 +13,8 @@ export default function getSynonyms(keyword) {
         });
       }
       return acc.concat(synonymsFound);
-    }, []));
+    }, []))
+    .catch((error) => {
+      console.log(error);
+    });
 }

--- a/src/components/SynonymList/SynonymList.css
+++ b/src/components/SynonymList/SynonymList.css
@@ -2,3 +2,8 @@
   padding: 5px;
   min-width: 100px;
 }
+
+.error-message-box {
+  max-width: 100px;
+  text-align: center;
+}

--- a/src/components/SynonymList/SynonymList.js
+++ b/src/components/SynonymList/SynonymList.js
@@ -11,6 +11,7 @@ type SynonymListProps = {
 export default function SynonymList({ keyword, handleSelection, index }: SynonymListProps) {
   const [selectedWord, setSelectedWord] = useState(keyword);
   const [synonyms, setSynonyms] = useState([]);
+  const [loading, setLoading] = useState(true);
   const handleChange = (event) => {
     handleSelection(event, index);
     setSelectedWord(event.target.value);
@@ -20,6 +21,7 @@ export default function SynonymList({ keyword, handleSelection, index }: Synonym
   useEffect(() => {
     getSynonyms(keyword)
       .then((synonymsFound) => {
+        setLoading(false);
         if (synonymsFound) {
           setSynonyms(synonymsFound.slice(0, 20));
         }
@@ -54,7 +56,7 @@ export default function SynonymList({ keyword, handleSelection, index }: Synonym
         key={keyword}
       />
       <label htmlFor={keyword}>{keyword}</label>
-      { !synonymRadioBtns
+      { (!synonymRadioBtns && !loading)
         ? (
           <div className="error-message-box">
             <h4>

--- a/src/components/SynonymList/SynonymList.js
+++ b/src/components/SynonymList/SynonymList.js
@@ -56,6 +56,7 @@ export default function SynonymList({ keyword, handleSelection, index }: Synonym
         key={keyword}
       />
       <label htmlFor={keyword}>{keyword}</label>
+      { loading && <h4>Loading...</h4> }
       { (!synonymRadioBtns && !loading)
         ? (
           <div className="error-message-box">

--- a/src/components/SynonymList/SynonymList.js
+++ b/src/components/SynonymList/SynonymList.js
@@ -19,9 +19,11 @@ export default function SynonymList({ keyword, handleSelection, index }: Synonym
 
   useEffect(() => {
     getSynonyms(keyword)
-      .then((synonymsFound) => (
-        setSynonyms(synonymsFound.slice(0, 20))
-      ));
+      .then((synonymsFound) => {
+        if (synonymsFound) {
+          setSynonyms(synonymsFound.slice(0, 20));
+        }
+      });
   }, [keyword]);
 
   if (synonyms.length) {
@@ -53,7 +55,13 @@ export default function SynonymList({ keyword, handleSelection, index }: Synonym
       />
       <label htmlFor={keyword}>{keyword}</label>
       { !synonymRadioBtns
-        ? <h4>Please try another keyword</h4>
+        ? (
+          <div className="error-message-box">
+            <h4>
+              No synonyms found. Please try another keyword
+            </h4>
+          </div>
+        )
         : synonymRadioBtns }
     </div>
   );

--- a/src/components/SynonymList/SynonymList.js
+++ b/src/components/SynonymList/SynonymList.js
@@ -58,7 +58,7 @@ export default function SynonymList({ keyword, handleSelection, index }: Synonym
         ? (
           <div className="error-message-box">
             <h4>
-              No synonyms found. Please try another keyword
+              No synonyms found. Please try another keyword.
             </h4>
           </div>
         )


### PR DESCRIPTION
### Features
- None

### Refactors
- Closes #16
- Closes #17  
- Add `div` around error message to enable width adjustment
- Add catch to fetch call
- Add conditional for displaying synonyms list

### Issues and Technical Debt
- None

### Other Comments, Concerns, or Questions
- None

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective and works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran Lighthouse and WAVE accessibility audits and fixed errors/warnings
- [x] Any dependent changes have been merged and published in downstream modules
